### PR TITLE
feat: Swagger 추가 및 유세인트 이름 저장

### DIFF
--- a/src/main/kotlin/com/dev_camp/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/dev_camp/auth/service/AuthService.kt
@@ -44,11 +44,15 @@ class AuthService(
 
         try {
             driver.findElement(By.id("pwd")).submit()
-            Thread.sleep(500)
+            Thread.sleep(100)
             System.out.print(driver.currentUrl)
 
             if (driver.currentUrl.contains("https://saint.ssu.ac.kr/irj/portal")) {
-                val user = User(id = requestDto.studentId, name = "testName")
+                val userGreet = driver.findElement(By.xpath("/html/body/div[2]/div/div[2]/header/div[1]/div/span")).text
+                val idx = userGreet.indexOf("님")
+                val username = userGreet.substring(0,idx)
+                val user = User(id = requestDto.studentId, name = username)
+
                 //로그아웃 버튼 click
                 driver.findElement(By.xpath("/html/body/div[2]/div/div[2]/header/div[1]/div/div/button[2]")).click()
                 userRepository.save(user)
@@ -58,7 +62,7 @@ class AuthService(
                     accessToken = jwtTokenUtil.generateAccessToken(user.id!!),
                     refreshToken = jwtTokenUtil.generateAccessToken(user.id!!),
                 )
-            } else throw UnhandledAlertException("login failed")
+            } else throw LoginException()
 
         } catch (e: UnhandledAlertException) {
             driver.quit()

--- a/src/main/kotlin/com/dev_camp/config/WebDriverConfig.kt
+++ b/src/main/kotlin/com/dev_camp/config/WebDriverConfig.kt
@@ -16,9 +16,13 @@ class WebDriverConfig(){
     fun webDriver(): WebDriver {
         val chromeDriverPath = "C:\\terrace_pj\\chromedriver.exe"
         System.setProperty("webdriver.chrome.driver", chromeDriverPath)
+
         val options = ChromeOptions()
-            .addArguments("disable-gpu","--window-size=1920,1200")
-            .setHeadless(true)
+            .addArguments("headless")
+            .addArguments("disable-gpu")
+            .addArguments("window-size=1920x1080")
+            .addArguments("--blink-setting=imagesEnable=false")
+            .addArguments("--disable-popup-blocking")
 
         val driver = ChromeDriver(options)
         driver.setLogLevel(Level.WARNING)

--- a/src/main/kotlin/com/dev_camp/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dev_camp/security/config/SecurityConfig.kt
@@ -49,7 +49,7 @@ class SecurityConfig(private val jwtTokenUtil: JwtTokenUtil, private val authent
         web.ignoring()
             .mvcMatchers(HttpMethod.POST, "/v1/auth/update-token")
             .mvcMatchers(HttpMethod.POST, "/v1/auth/login")
-            .mvcMatchers(HttpMethod.GET, "/swagger-ui/**")
+            .mvcMatchers(HttpMethod.GET, "/swagger-ui/**","swagger-resources/**","/v3/api-docs/**")
             .mvcMatchers(HttpMethod.GET, "/actuator/**")
     }
 


### PR DESCRIPTION
# 주요 변경사항
- config에 swagger-resource, v3/api-docs추가
- 유세인트에서 이름까지 가져와 user의 name에 저장.

# 유의점
- swagger에서 확인 결과 auth/login이 꽤 오래걸림. api요청마다 webdriver을 재시작하기도 하고
,메모리 관련 문제도 있을 것 같아 계속 수정 예정.
- user의 name에 한글이름을 넣고 save하면 db에서 mysql Data truncation: Incorrect string value:
에러가 발생함. users 테이블의 charset이 한글을 처리하지 못하고 있는 것 같아  
ALTER TABLE users convert to charset UTF8;   이 필요해보임