### PR TITLE
feat: 예약 생성 후 10분 대기

### DIFF
--- a/src/main/kotlin/com/dev_camp/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/dev_camp/config/AsyncConfig.kt
@@ -1,0 +1,22 @@
+package com.dev_camp.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@EnableAsync
+@Configuration
+class AsyncConfig {
+    @Bean("reservationTaskExecutor")
+    fun asyncTaskExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 12
+        executor.maxPoolSize = 20
+        executor.setQueueCapacity(0)
+        executor.threadNamePrefix = "reservation-executor-"
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/com/dev_camp/reservation/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/dev_camp/reservation/controller/ReservationApiController.kt
@@ -2,19 +2,23 @@ package com.dev_camp.reservation.controller
 
 import com.dev_camp.config.annotation.LoggedInUser
 import com.dev_camp.reservation.domain.Reservation
+import com.dev_camp.reservation.service.AsyncService
 import com.dev_camp.reservation.service.ReservationService
-import com.dev_camp.user.domain.User
+import com.dev_camp.user.dto.UserDto
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("v1/reservation")
 class ReservationApiController (
-    private val reservationService: ReservationService
+    private val reservationService: ReservationService,
+    private val asyncService: AsyncService
 ) {
     @PostMapping("/{terraceId}")
     @ResponseStatus(HttpStatus.CREATED)
-    fun create(@PathVariable terraceId: Int, @LoggedInUser user: User) : Reservation {
-        return reservationService.createReservation(terraceId, user)
+    fun create(@PathVariable terraceId: Int, @LoggedInUser userDto: UserDto) : Reservation {
+        val created: Reservation = reservationService.createReservation(terraceId, userDto.id)
+        asyncService.waitCheckIn(created.id!!)
+        return created
     }
 }

--- a/src/main/kotlin/com/dev_camp/reservation/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/dev_camp/reservation/controller/ReservationApiController.kt
@@ -17,7 +17,7 @@ class ReservationApiController (
     @PostMapping("/{terraceId}")
     @ResponseStatus(HttpStatus.CREATED)
     fun create(@PathVariable terraceId: Int, @LoggedInUser userDto: UserDto) : Reservation {
-        val created: Reservation = reservationService.createReservation(terraceId, userDto.id)
+        val created = reservationService.createReservation(terraceId, userDto.id)
         asyncService.waitCheckIn(created.id!!)
         return created
     }

--- a/src/main/kotlin/com/dev_camp/reservation/domain/Reservation.kt
+++ b/src/main/kotlin/com/dev_camp/reservation/domain/Reservation.kt
@@ -20,4 +20,7 @@ class Reservation(
     @field:ManyToOne(fetch = FetchType.LAZY)
     @field:JoinColumn(name = "user_id")
     val user: User,
+
+    @field:Column(name = "is_checked_in")
+    var isCheckedIn: Boolean
 ) : CreatedAtEntity()

--- a/src/main/kotlin/com/dev_camp/reservation/service/AsyncService.kt
+++ b/src/main/kotlin/com/dev_camp/reservation/service/AsyncService.kt
@@ -1,0 +1,5 @@
+package com.dev_camp.reservation.service
+
+interface AsyncService {
+    fun waitCheckIn(reservationId: Int)
+}

--- a/src/main/kotlin/com/dev_camp/reservation/service/AsyncServiceImpl.kt
+++ b/src/main/kotlin/com/dev_camp/reservation/service/AsyncServiceImpl.kt
@@ -1,0 +1,40 @@
+package com.dev_camp.reservation.service
+
+import com.dev_camp.reservation.domain.ReservationRepository
+import com.dev_camp.terrace.domain.Terrace
+import com.dev_camp.terrace.domain.TerraceRepository
+import com.dev_camp.terrace.domain.TerraceStatus
+import com.dev_camp.terrace.exception.TerraceIdNotFoundException
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import javax.transaction.Transactional
+
+@Service
+class AsyncServiceImpl(
+    private val terraceRepository: TerraceRepository,
+    private val reservationRepository: ReservationRepository
+) : AsyncService {
+    @Async("reservationTaskExecutor")
+    @Transactional
+    override fun waitCheckIn(reservationId: Int) {
+        val minutes = 10
+
+        for (i in 1..minutes) {
+            Thread.sleep(1 * 60 * 1000)
+
+            val reservation = reservationRepository.findById(reservationId).orElse(null)
+
+            if (reservation == null) //예약 취소된 경우
+                return
+
+            if (reservation.isCheckedIn) // 체크인 된 경우
+                return
+        }
+
+        val reservation = reservationRepository.findById(reservationId).orElseThrow { TerraceIdNotFoundException() }
+        val terrace  = terraceRepository.findById(reservation.terrace.id).orElseThrow { TerraceIdNotFoundException() }
+        reservationRepository.delete(reservation)
+        terrace.status = TerraceStatus.AVAILABLE
+        terraceRepository.save(terrace)
+    }
+}

--- a/src/main/kotlin/com/dev_camp/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/dev_camp/reservation/service/ReservationService.kt
@@ -1,8 +1,7 @@
 package com.dev_camp.reservation.service
 
 import com.dev_camp.reservation.domain.Reservation
-import com.dev_camp.user.domain.User
 
 interface ReservationService {
-    fun createReservation(terraceId: Int, user: User) : Reservation
+    fun createReservation(terraceId: Int, userId: String) : Reservation
 }

--- a/src/main/kotlin/com/dev_camp/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/com/dev_camp/reservation/service/ReservationServiceImpl.kt
@@ -8,21 +8,32 @@ import com.dev_camp.terrace.domain.TerraceStatus
 import com.dev_camp.terrace.exception.TerraceIdNotFoundException
 import com.dev_camp.terrace.exception.UnavailableTerraceException
 import com.dev_camp.user.domain.User
+import com.dev_camp.user.domain.UserRepository
 import org.springframework.stereotype.Service
+import javax.transaction.Transactional
 
 @Service
 class ReservationServiceImpl (
     private val reservationRepository: ReservationRepository,
-    private val terraceRepository: TerraceRepository
+    private val terraceRepository: TerraceRepository,
+    private val userRepository: UserRepository
 ) : ReservationService {
-    override fun createReservation(terraceId: Int, user: User) : Reservation {
+    @Transactional
+    override fun createReservation(terraceId: Int, userId: String) : Reservation {
         val terrace: Terrace = terraceRepository.findById(terraceId).orElseThrow { TerraceIdNotFoundException() }
+        val user: User = userRepository.findById(userId).orElseThrow { TerraceIdNotFoundException() }
+        val reservation: Reservation
 
-        return when (terrace.status) {
-            TerraceStatus.AVAILABLE -> return reservationRepository.save(Reservation(null, terrace, user))
+        when (terrace.status) {
+            TerraceStatus.AVAILABLE -> reservation = reservationRepository.save(Reservation(null, terrace, user, false))
             TerraceStatus.BOOK -> throw UnavailableTerraceException("이미 예약된 테라스입니다.")
             TerraceStatus.CLOSED -> throw UnavailableTerraceException("사용 불가능한 테라스입니다.")
             TerraceStatus.USING -> throw UnavailableTerraceException("사용 중인 테라스입니다.")
         }
+
+        terrace.status = TerraceStatus.BOOK
+        terraceRepository.save(terrace)
+
+        return reservation
     }
 }

--- a/src/main/kotlin/com/dev_camp/terrace/domain/Terrace.kt
+++ b/src/main/kotlin/com/dev_camp/terrace/domain/Terrace.kt
@@ -15,7 +15,7 @@ class Terrace(
 
     @field:Column(nullable = false, name = "status")
     @field:Enumerated(value = EnumType.STRING)
-    val status: TerraceStatus = TerraceStatus.AVAILABLE
+    var status: TerraceStatus = TerraceStatus.AVAILABLE
 ) {
     fun toDto(): TerraceDto {
         return TerraceDto(id, floor, status)


### PR DESCRIPTION
# 개요
- 예약 생성 후 10분 이내에 입실하지 않으면 예약 삭제하고 테라스 상태 변경

# 작업사항
- 입실했는지 확인하기 위해 reservation table에 is_checked_in 컬럼 추가함 (체크인 시 true로 업데이트 해줘야 함)
- ThreadPoolTaskExecutor을 이용해 스레드 생성 후 10분 동안 1분 간격으로 체크인 되었는지 확인
- reservation이 null 값(예약 취소)이거나 is_checked_in값이 true(체크인 완료)이면 스레드 끝냄
- 10분이 지났는데도 is_checked_in값이 false이면 테라스 상태 정보 변경하고 예약 삭제

show create table reservation; 한 결과입니다.
```
CREATE TABLE `reservation` (
  `reservation_id` int(11) NOT NULL AUTO_INCREMENT,
  `terrace_id` int(11) NOT NULL,
  `created_at` datetime NOT NULL DEFAULT current_timestamp(),
  `is_checked_in` tinyint(1) DEFAULT NULL,
  `user_id` varchar(8) DEFAULT NULL,
  PRIMARY KEY (`reservation_id`),
  KEY `terrace_id` (`terrace_id`),
  KEY `user_id` (`user_id`),
  CONSTRAINT `reservation_ibfk_1` FOREIGN KEY (`terrace_id`) REFERENCES `terrace` (`terrace_id`),
  CONSTRAINT `reservation_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`)
) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=utf8mb4
```